### PR TITLE
Jdapena/spec 4223 marlin fix launch

### DIFF
--- a/src/net/third_party/quiche/src/quic/core/frames/quic_frame.h
+++ b/src/net/third_party/quiche/src/quic/core/frames/quic_frame.h
@@ -110,8 +110,15 @@ struct QUIC_EXPORT_PRIVATE QuicFrame {
 
 static_assert(sizeof(QuicFrame) <= 24,
               "Frames larger than 24 bytes should be referenced by pointer.");
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Winvalid-offsetof"
+#endif
 static_assert(offsetof(QuicStreamFrame, type) == offsetof(QuicFrame, type),
               "Offset of |type| must match in QuicFrame and QuicStreamFrame");
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 // A inline size of 1 is chosen to optimize the typical use case of
 // 1-stream-frame in QuicTransmissionInfo.retransmittable_frames.

--- a/src/net/third_party/quiche/src/quic/core/frames/quic_inlined_frame.h
+++ b/src/net/third_party/quiche/src/quic/core/frames/quic_inlined_frame.h
@@ -17,8 +17,15 @@ namespace quic {
 template <typename DerivedT>
 struct QUIC_EXPORT_PRIVATE QuicInlinedFrame {
   QuicInlinedFrame(QuicFrameType type) : type(type) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Winvalid-offsetof"
+#endif
     static_assert(offsetof(DerivedT, type) == 0,
                   "type must be the first field.");
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     static_assert(sizeof(DerivedT) <= 24,
                   "Frames larger than 24 bytes should not be inlined.");
   }

--- a/src/third_party/skia/include/private/SkFloatingPoint.h
+++ b/src/third_party/skia/include/private/SkFloatingPoint.h
@@ -159,7 +159,15 @@ static inline int64_t sk_float_saturate2int64(float x) {
 // Cast double to float, ignoring any warning about too-large finite values being cast to float.
 // Clang thinks this is undefined, but it's actually implementation defined to return either
 // the largest float or infinity (one of the two bracketing representable floats).  Good enough!
+#if defined(__GNUC__) && __GNUC__ >= 8
+__attribute__((no_sanitize("float-cast-overflow")))
+#else
+# if defined(__GNUC__)
+__attribute__((no_sanitize_undefined))
+# else
 [[clang::no_sanitize("float-cast-overflow")]]
+# endif
+#endif
 static inline float sk_double_to_float(double x) {
     return static_cast<float>(x);
 }
@@ -226,12 +234,28 @@ static inline float sk_float_rsqrt(float x) {
 // IEEE defines how float divide behaves for non-finite values and zero-denoms, but C does not
 // so we have a helper that suppresses the possible undefined-behavior warnings.
 
+#if defined(__GNUC__) && __GNUC__ >= 8
+__attribute__((no_sanitize("float-divide-by-zero")))
+#else
+# if defined(__GNUC__)
+__attribute__((no_sanitize_undefined))
+# else
 [[clang::no_sanitize("float-divide-by-zero")]]
+# endif
+#endif
 static inline float sk_ieee_float_divide(float numer, float denom) {
     return numer / denom;
 }
 
+#if defined(__GNUC__) && __GNUC__ >= 8
+__attribute__((no_sanitize("float-cast-overflow")))
+#else
+# if defined(__GNUC__)
+__attribute__((no_sanitize_undefined))
+# else
 [[clang::no_sanitize("float-divide-by-zero")]]
+# endif
+#endif
 static inline double sk_ieee_double_divide(double numer, double denom) {
     return numer / denom;
 }

--- a/src/ui/base/ui_base_switches.cc
+++ b/src/ui/base/ui_base_switches.cc
@@ -101,4 +101,8 @@ const char kUseSystemClipboard[] = "use-system-clipboard";
 // webapp
 const char kAglAppId[] = "agl-appid";
 
+// Specifies that this application is the only one that binds to agl_shell
+// wayland protocol
+const char kIsAglShell[] = "is-agl-shell";
+
 }  // namespace switches

--- a/src/ui/base/ui_base_switches.h
+++ b/src/ui/base/ui_base_switches.h
@@ -44,6 +44,7 @@ UI_BASE_EXPORT extern const char kDisallowNonExactResourceReuse[];
 UI_BASE_EXPORT extern const char kMangleLocalizedStrings[];
 
 UI_BASE_EXPORT extern const char kAglAppId[];
+UI_BASE_EXPORT extern const char kIsAglShell[];
 
 }  // namespace switches
 

--- a/src/ui/ozone/platform/wayland/host/wayland_output.cc
+++ b/src/ui/ozone/platform/wayland/host/wayland_output.cc
@@ -33,8 +33,23 @@ void WaylandOutput::Initialize(Delegate* delegate) {
 
 void WaylandOutput::TriggerDelegateNotification() const {
   DCHECK(!rect_in_physical_pixels_.IsEmpty());
-  delegate_->OnOutputHandleMetrics(output_id_, rect_in_physical_pixels_,
+  gfx::Rect transformed_rect = rect_in_physical_pixels_;
+  transformed_rect.Transpose();
+  delegate_->OnOutputHandleMetrics(output_id_, transformed_rect,
                                    scale_factor_);
+}
+
+// static
+bool WaylandOutput::ShouldSwapAxis(int32_t output_transform) {
+  switch(output_transform) {
+    case WL_OUTPUT_TRANSFORM_90:
+    case WL_OUTPUT_TRANSFORM_270:
+    case WL_OUTPUT_TRANSFORM_FLIPPED_90:
+    case WL_OUTPUT_TRANSFORM_FLIPPED_270:
+      return true;
+    default:
+     return false;
+  }
 }
 
 // static

--- a/src/ui/ozone/platform/wayland/host/wayland_output.h
+++ b/src/ui/ozone/platform/wayland/host/wayland_output.h
@@ -45,6 +45,7 @@ class WaylandOutput {
 
  private:
   static constexpr int32_t kDefaultScaleFactor = 1;
+  static bool ShouldSwapAxis(int32_t wayland_transform);
 
   // Callback functions used for setting geometric properties of the output
   // and available modes.
@@ -74,6 +75,7 @@ class WaylandOutput {
   wl::Object<wl_output> output_;
   int32_t scale_factor_ = kDefaultScaleFactor;
   gfx::Rect rect_in_physical_pixels_;
+  bool swap_axis = false;
 
   Delegate* delegate_ = nullptr;
 

--- a/src/ui/ozone/platform/wayland/host/wayland_window.cc
+++ b/src/ui/ozone/platform/wayland/host/wayland_window.cc
@@ -299,7 +299,19 @@ WaylandWindow::SetAglReady(void)
   if (!connection_->agl_shell_manager) {
       return;
   }
-  connection_->agl_shell_manager->ready();
+
+  // Delay activation to ensure that all the setup is done
+  // TODO(rzanoni): find a more deterministic way of doing this
+  set_ready_timer_.Start(FROM_HERE,
+                         base::TimeDelta::FromMilliseconds(500),
+                         this,
+                         &WaylandWindow::SetReadyCallback);
+}
+
+
+void WaylandWindow::SetReadyCallback() {
+    connection_->agl_shell_manager->ready();
+    connection_->ScheduleFlush();
 }
 
 bool WaylandWindow::CanDispatchEvent(const PlatformEvent& event) {

--- a/src/ui/ozone/platform/wayland/host/wayland_window.h
+++ b/src/ui/ozone/platform/wayland/host/wayland_window.h
@@ -13,6 +13,7 @@
 #include "base/containers/flat_set.h"
 #include "base/gtest_prod_util.h"
 #include "base/memory/ref_counted.h"
+#include "base/timer/timer.h"
 #include "ui/events/platform/platform_event_dispatcher.h"
 #include "ui/gfx/geometry/rect.h"
 #include "ui/gfx/native_widget_types.h"
@@ -230,6 +231,8 @@ class WaylandWindow : public PlatformWindow, public PlatformEventDispatcher {
   // Returns a root parent window.
   WaylandWindow* GetRootParentWindow();
 
+  void SetReadyCallback();
+
   // Install a surface listener and start getting wl_output enter/leave events.
   void AddSurfaceListener();
 
@@ -308,6 +311,8 @@ class WaylandWindow : public PlatformWindow, public PlatformEventDispatcher {
 
   // The type of the current WaylandWindow object.
   ui::PlatformWindowType type_ = ui::PlatformWindowType::kWindow;
+
+  base::OneShotTimer set_ready_timer_;
 
   DISALLOW_COPY_AND_ASSIGN(WaylandWindow);
 };


### PR DESCRIPTION
Several changes:
* Drop patches added to recipe so they are now part of the chromium marlin branch.
* Properly consider display framebuffer dimensions using wayland transform (if rotation is 90 or 270, then X/Y/widht/height should be transposed).
* Allow to run WAM without it being the homescreen and launcher, by allowing to run if another application binds to agl_shell protocol. This is required to run WAM in Qt-based UI.